### PR TITLE
Add API key management functionality to AuthController and AuthService

### DIFF
--- a/open/src/app.settings.ts
+++ b/open/src/app.settings.ts
@@ -6,7 +6,7 @@ export const RPC_URL = process.env.RPC_URL || ''
 
 export const JWT_SECRET = process.env.JWT_SECRET || 'secret'
 export const JWT_EXP = process.env.JWT_EXP || '1h'
-
+export const JWT_API_EXP = process.env.JWT_API_EXP || '1y'
 export const REDIS_HOST = process.env.REDIS_HOST || 'localhost'
 export const REDIS_PORT = process.env.REDIS_PORT || '6379'
 export const REDIS_USER = process.env.REDIS_USER || 'default'
@@ -40,7 +40,7 @@ export function setAppSetting(app: INestApplication) {
     optionsSuccessStatus: 204
   })
 }
-console.log('Database URL:', process.env.DATABASE_URL);
-console.log('API URL:', process.env.API_URL);
-console.log('RPC URL:', process.env.RPC_URL);
-console.log('APP PORT:', process.env.APP_PORT);
+console.log('Database URL:', process.env.DATABASE_URL)
+console.log('API URL:', process.env.API_URL)
+console.log('RPC URL:', process.env.RPC_URL)
+console.log('APP PORT:', process.env.APP_PORT)

--- a/open/src/auth/auth.controller.ts
+++ b/open/src/auth/auth.controller.ts
@@ -1,7 +1,19 @@
-import { Controller, Post, Body, UnauthorizedException, Param } from '@nestjs/common'
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger'
+import {
+  Controller,
+  Post,
+  Body,
+  UnauthorizedException,
+  Param,
+  UseGuards,
+  Req,
+  Get,
+  Delete
+} from '@nestjs/common'
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger'
 import { AuthService } from './auth.service'
 import { VerifySignatureDto } from './dto/verify.dto'
+import { JwtAuthGuard } from './auth.guard'
+import { Request } from 'express'
 
 @ApiTags('Authorization')
 @Controller({ path: 'auth', version: '1' })
@@ -28,5 +40,38 @@ export class AuthController {
       throw new UnauthorizedException('Invalid signature')
     }
     return { accessToken: token }
+  }
+
+  @Post('api-key')
+  @ApiOperation({ summary: 'Generate an API key for a user' })
+  @ApiResponse({ status: 200, description: 'Returns an API key for the user' })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT')
+  async generateApiKey(@Req() req: Request) {
+    return {
+      message: 'success',
+      data: await this.authService.generateApiKey(req.user['address'], req.user['userId'])
+    }
+  }
+
+  @Get('api-keys')
+  @ApiOperation({ summary: 'Get all API keys for a user' })
+  @ApiResponse({ status: 200, description: 'Returns all API keys for the user' })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT')
+  async getApiKeys(@Req() req: Request) {
+    return { message: 'success', data: await this.authService.apiKeys(req.user['userId']) }
+  }
+
+  @Delete('api-key/:id')
+  @ApiOperation({ summary: 'Delete an API key for a user' })
+  @ApiResponse({ status: 200, description: 'Returns the deleted API key' })
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT')
+  async deleteApiKey(@Param('id') id: string, @Req() req: Request) {
+    return {
+      message: 'success',
+      data: await this.authService.deleteApiKey(parseInt(id), req.user['userId'])
+    }
   }
 }

--- a/open/src/auth/auth.service.ts
+++ b/open/src/auth/auth.service.ts
@@ -1,8 +1,10 @@
-import { Injectable } from '@nestjs/common'
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common'
 import { PrismaService } from '../prisma.service'
 import { JwtService } from '@nestjs/jwt'
 import * as crypto from 'crypto'
 import { verifyMessage } from 'ethers'
+import { JWT_API_EXP, JWT_EXP } from '../app.settings'
+import { UserApiKey } from '@prisma/client'
 
 @Injectable()
 export class AuthService {
@@ -23,7 +25,7 @@ export class AuthService {
       const recoveredAddress = verifyMessage(message, signature)
       // insert user into db,update if already exists
       const lowerCaseAddress = recoveredAddress.toLowerCase()
-      await this.prisma.user.upsert({
+      const user = await this.prisma.user.upsert({
         where: { walletAddress: lowerCaseAddress },
         update: {},
         create: {
@@ -33,19 +35,53 @@ export class AuthService {
         }
       })
 
-      return await this.generateJwtToken(lowerCaseAddress)
+      return await this.generateJwtToken(lowerCaseAddress, user.id)
     } catch (error) {
       console.error('Error verifying signature:', error)
       return ''
     }
   }
 
-  async generateJwtToken(address: string): Promise<string> {
-    const payload = { sub: { address } }
-    return this.jwtService.sign(payload)
+  async generateJwtToken(
+    address: string,
+    userId: number,
+    expireTime: string = JWT_EXP
+  ): Promise<string> {
+    const payload = { sub: { address, userId } }
+    return this.jwtService.sign(payload, { expiresIn: expireTime })
   }
 
   private getMessage(nonce: string, timestamp: number): string {
     return `Please sign this message to authenticate: Nonce: ${nonce} Timestamp: ${timestamp}`
+  }
+
+  async generateApiKey(address: string, userId: number): Promise<string> {
+    const apiKey = await this.generateJwtToken(address, userId, JWT_API_EXP)
+    await this.prisma.userApiKey.create({
+      data: {
+        userId,
+        apiKey,
+        expiresAt: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000) // 1 year from now
+      }
+    })
+    return apiKey
+  }
+
+  async apiKeys(userId: number): Promise<UserApiKey[]> {
+    return this.prisma.userApiKey.findMany({
+      where: { userId }
+    })
+  }
+
+  async deleteApiKey(apiKeyId: number, userId: number): Promise<void> {
+    const apiKey = await this.prisma.userApiKey.findUnique({
+      where: { id: apiKeyId, userId }
+    })
+    if (!apiKey) {
+      throw new HttpException('API key not found', HttpStatus.NOT_FOUND)
+    }
+    await this.prisma.userApiKey.delete({
+      where: { id: apiKeyId, userId }
+    })
   }
 }

--- a/open/src/auth/jwt.strategy.ts
+++ b/open/src/auth/jwt.strategy.ts
@@ -24,7 +24,8 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     }
 
     return {
-      address: sub.address.toLowerCase()
+      address: sub.address.toLowerCase(),
+      userId: sub.userId
     }
   }
 }


### PR DESCRIPTION
- Introduced endpoints for generating, retrieving, and deleting API keys in AuthController.
- Updated AuthService to handle API key generation and management, including expiration settings.
- Enhanced JWT token generation to include user ID in the payload.
- Added JWT_API_EXP configuration for API key expiration duration.
- Cleaned up console log statements in app.settings.ts for consistency.